### PR TITLE
Fix MunGuid compare and add equal operators to RuntimeFunction

### DIFF
--- a/include/mun/function.h
+++ b/include/mun/function.h
@@ -27,6 +27,8 @@ struct RuntimeFunction {
 
     RuntimeFunction(const RuntimeFunction&) = default;
     RuntimeFunction(RuntimeFunction&&) = default;
+    RuntimeFunction& operator=(const RuntimeFunction&) = default;
+    RuntimeFunction& operator=(RuntimeFunction&&) = default;
 
     std::string name;
     std::vector<MunTypeInfo const*> arg_types;

--- a/include/mun/reflection.h
+++ b/include/mun/reflection.h
@@ -12,7 +12,7 @@
 namespace mun {
 constexpr inline bool operator==(const MunGuid& lhs, const MunGuid& rhs) noexcept {
     for (auto idx = 0; idx < 16; ++idx) {
-        if (lhs.b[idx] != rhs.b[idx]) {
+        if (lhs._0[idx] != rhs._0[idx]) {
             return false;
         }
     }


### PR DESCRIPTION
- Fix MunGuid::operator== compile error
- Add missing assignment operators for RuntimeFunction